### PR TITLE
fix(auth): update avatar_id

### DIFF
--- a/src/database/init.sql
+++ b/src/database/init.sql
@@ -28,8 +28,7 @@ CREATE TYPE housesize_letter_type AS ENUM ('S', 'M', 'L', 'XL', 'XXL');
 CREATE TYPE group_role_type AS ENUM ('OWNER', 'MEMBER');
 
 -- Create sequence for avatar IDs
--- This sequence will cycle through numbers 1 to 12, representing avatar IDs
-CREATE SEQUENCE avatar_seq MINVALUE 1 MAXVALUE 12 CYCLE;
+CREATE SEQUENCE avatar_seq MINVALUE 1 MAXVALUE 5 CYCLE;
 
 -- Create "users" table
 CREATE TABLE users (

--- a/src/database/init.sql
+++ b/src/database/init.sql
@@ -27,6 +27,9 @@ CREATE TYPE checkin_status_type AS ENUM ('PRE_REGISTER', 'EVENT_REGISTER');
 CREATE TYPE housesize_letter_type AS ENUM ('S', 'M', 'L', 'XL', 'XXL');
 CREATE TYPE group_role_type AS ENUM ('OWNER', 'MEMBER');
 
+-- Create sequence for avatar IDs
+-- This sequence will cycle through numbers 1 to 12, representing avatar IDs
+CREATE SEQUENCE avatar_seq MINVALUE 1 MAXVALUE 12 CYCLE;
 
 -- Create "users" table
 CREATE TABLE users (
@@ -46,7 +49,7 @@ CREATE TABLE users (
     food_allergy TEXT DEFAULT NULL,
     drug_allergy TEXT DEFAULT NULL,
     illness TEXT DEFAULT NULL,
-    avatar_id SMALLINT DEFAULT 1 NOT NULL,
+    avatar_id SMALLINT DEFAULT DEFAULT  nextval('avatar_seq') NOT NULL,
     group_id UUID,
     group_role group_role_type DEFAULT 'OWNER',
     role role_type DEFAULT 'FRESHMAN' NOT NULL,

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -90,7 +90,6 @@ const router = Router();
  *               - parent_name
  *               - parent_phone_number
  *               - parent_relationship
- *               - avatar_id
  *     responses:
  *       '201':
  *         description: User registered successfully.

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -7,7 +7,7 @@ import { CustomError } from '../types/error';
 import { passwordStrengthValidator, validateCitizenIdChecksum } from '../utils/validationUtils';
 // Register Logic
 export const register = async (userData: UserRegistrationRequest) => {
-  const { student_id, citizen_id, password ,...rest} = userData;
+  const { student_id, citizen_id, password , avatar_id} = userData;
 
   // check if user already exists
   const existingUser = await userService.findUserByStudentIdAndCitizenId(student_id, citizen_id);
@@ -37,7 +37,7 @@ export const register = async (userData: UserRegistrationRequest) => {
 
   // crerate user for database
   const role = (userData as any).role || 'FRESHMAN'; //testing purposes naja
-  const newUser : User = {...userData, password_hash, role, created_at: new Date(), updated_at: new Date()}
+  const newUser : User = {...userData, password_hash, role,avatar_id, created_at: new Date(), updated_at: new Date()}
   const addedUser = await userService.createUser(newUser);
   // console.log('User created successfully:', addedUser);
   return addedUser;
@@ -46,6 +46,7 @@ export const register = async (userData: UserRegistrationRequest) => {
 // Login 
 export const login = async (student_id: string, citizen_id:string ,password: string): Promise<{ token: string; user: User }> => {
 
+  // check if user exists
   const user = await userService.findUserByStudentIdAndCitizenId(student_id,citizen_id);
   if(!user){
     const error: CustomError = new Error('User not found.Student ID or Citizen ID is incorrect.');

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -35,7 +35,8 @@ export const createUser = async (userData: User): Promise<User> => {
         student_id, citizen_id, prefix, first_name, last_name, nickname,
         academic_year, faculty, password_hash, phone_number,
         parent_name, parent_phone_number, parent_relationship, food_allergy, drug_allergy, illness, avatar_id, role
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16 ,$17,$18) RETURNING *`, 
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16 ,COALESCE($17, nextval('avatar_seq')),$18) RETURNING *`,
+ 
       [
         student_id,
         citizen_id,

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -18,7 +18,7 @@ export interface User {
   food_allergy?: string; 
   drug_allergy?: string; 
   illness?: string;
-  avatar_id: number;
+  avatar_id?: number;
   role: RoleType;
   created_at: Date;
   updated_at: Date;
@@ -44,7 +44,7 @@ export interface UserRegistrationRequest {
   food_allergy?: string; 
   drug_allergy?: string; 
   illness?: string; 
-  avatar_id: number; 
+  avatar_id?: number; 
 }
 
 // Interface UserPublic สำหรับข้อมูลที่ส่งกลับไปยัง Frontend


### PR DESCRIPTION
from this brief "/api/auth/register เอ้ออ อันนี้มีไอเดียว่า avatar_id เราสามารถวนแจกไอดีไปเรื่อยๆได้ไหม แบบ คนแรกได้เลข 0 คนสองได้ 1 ... คนที่ 12 ได้เลข 0 วนไป มันจะได้กระจาย ? หลังบ้านจะ track ยากป่าว"

  - Adds a new avatar_seq sequence in init.sql and sets the avatar_id column default to nextval('avatar_seq').

  - Updates createUser in userService.ts to use COALESCE($17, nextval('avatar_seq')) so a provided value is used when available but falls back to the next sequence number otherwise.

   - Makes avatar_id optional in the User and UserRegistrationRequest interfaces.

   - Modifies authService.register to accept a provided avatar_id or pass undefined, letting the DB assign a random one through the sequence.

   - Cleans up API docs in authRoutes.ts to reflect the optional avatar field.
   - Update : cycle to 5 instead of 12